### PR TITLE
Fix quest reservation conversion bounds for legacy metaruns

### DIFF
--- a/src/metarun.c
+++ b/src/metarun.c
@@ -495,7 +495,7 @@ errr load_metaruns(bool create_if_missing)
                 
                 /* Initialize quest tracking fields for old format */
                 metaruns[i].completed_quests = 0;
-                for (int j = 0; j < 15; j++) {
+                for (int j = 0; j < (int)N_ELEMENTS(metaruns[i].quest_reserved); j++) {
                     metaruns[i].quest_reserved[j] = 0;
                 }
             }


### PR DESCRIPTION
## Summary
- update the legacy metarun conversion path to zero quest_reserved using its true array length, preventing overflow

## Testing
- make -f Makefile.std metarun.o
- /tmp/test_metarun_conversion


------
https://chatgpt.com/codex/tasks/task_b_68dacf054a00832b98568fd2c4fd587d